### PR TITLE
Added replacement for leading quotes. Fixes #5

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,7 +45,9 @@ exports.tokenBefore = function(token) {
     var alternateEscape = new RegExp('\\\\' + alternate, 'g');
     content = content.replace(alternateEscape, alternate);
 
-    var quoteEscape = new RegExp('([^\\\\])' + quote, 'g');
+    // If the first character is a quote, escape it (e.g. "'hello" -> '\'hello')
+    //   or if a character is an unescaped quote, escape it (e.g. "hello'" -> 'hello\'')
+    var quoteEscape = new RegExp('(^|[^\\\\])' + quote, 'g');
     content = content.replace(quoteEscape, '$1\\' + quote);
 
     token.value = quote + content + quote;

--- a/test/compare/input.js
+++ b/test/compare/input.js
@@ -19,6 +19,10 @@ var maecennas = 'ipsum \'dolor\' sit "amet"';
 
 var unnecessaryEscape = 'bar \'baz\' \"dolor\"';
 
+var leadingSingle = "'";
+var leadingDouble = '"';
+var unnecessaryEscapeSingle = '\'';
+
 
 // multiline strings ====
 

--- a/test/compare/output-double-avoid.js
+++ b/test/compare/output-double-avoid.js
@@ -19,6 +19,10 @@ var maecennas = "ipsum 'dolor' sit \"amet\"";
 
 var unnecessaryEscape = "bar 'baz' \"dolor\"";
 
+var leadingSingle = "'";
+var leadingDouble = '"';
+var unnecessaryEscapeSingle = "'";
+
 
 // multiline strings ====
 

--- a/test/compare/output-double.js
+++ b/test/compare/output-double.js
@@ -19,6 +19,10 @@ var maecennas = "ipsum 'dolor' sit \"amet\"";
 
 var unnecessaryEscape = "bar 'baz' \"dolor\"";
 
+var leadingSingle = "'";
+var leadingDouble = "\"";
+var unnecessaryEscapeSingle = "'";
+
 
 // multiline strings ====
 

--- a/test/compare/output-single-avoid.js
+++ b/test/compare/output-single-avoid.js
@@ -19,6 +19,10 @@ var maecennas = 'ipsum \'dolor\' sit "amet"';
 
 var unnecessaryEscape = 'bar \'baz\' "dolor"';
 
+var leadingSingle = "'";
+var leadingDouble = '"';
+var unnecessaryEscapeSingle = "'";
+
 
 // multiline strings ====
 

--- a/test/compare/output-single.js
+++ b/test/compare/output-single.js
@@ -19,6 +19,10 @@ var maecennas = 'ipsum \'dolor\' sit "amet"';
 
 var unnecessaryEscape = 'bar \'baz\' "dolor"';
 
+var leadingSingle = '\'';
+var leadingDouble = '"';
+var unnecessaryEscapeSingle = '\'';
+
 
 // multiline strings ====
 


### PR DESCRIPTION
As mentioned in #5, there was a problem with replacing strings like `"'"` (double single double). I traced down the issue to:

https://github.com/millermedeiros/esformatter-quotes/blob/v1.0.0/index.js#L48-L49

```js
var quoteEscape = new RegExp('([^\\\\])' + quote, 'g');
content = content.replace(quoteEscape, '$1\\' + quote);
```

This `RegExp` searches for a non-slash character followed by a quote. Unfortunately, at the start of the string there are no preceding characters so this first one gets skipped. To resolve this, I moved the group to match against `^` (start of string) or non-slash character:

```js
var quoteEscape = new RegExp('([^|^\\\\])' + quote, 'g');
```

In this PR:

- Added test cases against leading string character
- Patched `index.js` with updated `RegExp`
