### PR TITLE
Added successive quote escaping. Fixes #7

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,8 +48,12 @@ exports.tokenBefore = function(token) {
 
     // If the first character is a quote, escape it (e.g. "'hello" -> '\'hello')
     //   or if a character is an unescaped quote, escape it (e.g. "hello'" -> 'hello\'')
-    var quoteEscape = new RegExp('(^|[^\\\\])' + quote, 'g');
-    content = content.replace(quoteEscape, '$1\\' + quote);
+    // If we are an unescaped set of quotes, escape them (e.g. "hello'" -> 'hello\'', "hello''" -> 'hello\'\'')
+    // DEV: JavaScript starts the next match at the end of the current one, causing us to need a function or loop.
+    var quoteEscape = new RegExp('(^|[^\\\\])(' + quote + '+)', 'g');
+    content = content.replace(quoteEscape, function replaceQuotes (input, group1, group2, match) {
+      return group1 + new Array(group2.length + 1).join('\\' + quote);
+    });
 
     token.value = quote + content + quote;
   }

--- a/test/compare/input.js
+++ b/test/compare/input.js
@@ -23,6 +23,8 @@ var leadingSingle = "'";
 var leadingDouble = '"';
 var unnecessaryEscapeSingle = '\'';
 
+var successiveQuotes = ' \'\' ""';
+
 
 // multiline strings ====
 

--- a/test/compare/output-double-avoid.js
+++ b/test/compare/output-double-avoid.js
@@ -23,6 +23,8 @@ var leadingSingle = "'";
 var leadingDouble = '"';
 var unnecessaryEscapeSingle = "'";
 
+var successiveQuotes = " '' \"\"";
+
 
 // multiline strings ====
 

--- a/test/compare/output-double.js
+++ b/test/compare/output-double.js
@@ -23,6 +23,8 @@ var leadingSingle = "'";
 var leadingDouble = "\"";
 var unnecessaryEscapeSingle = "'";
 
+var successiveQuotes = " '' \"\"";
+
 
 // multiline strings ====
 

--- a/test/compare/output-single-avoid.js
+++ b/test/compare/output-single-avoid.js
@@ -23,6 +23,8 @@ var leadingSingle = "'";
 var leadingDouble = '"';
 var unnecessaryEscapeSingle = "'";
 
+var successiveQuotes = ' \'\' ""';
+
 
 // multiline strings ====
 

--- a/test/compare/output-single.js
+++ b/test/compare/output-single.js
@@ -23,6 +23,8 @@ var leadingSingle = '\'';
 var leadingDouble = '"';
 var unnecessaryEscapeSingle = '\'';
 
+var successiveQuotes = ' \'\' ""';
+
 
 // multiline strings ====
 


### PR DESCRIPTION
As reported in #7, we are currently not handling successive quotes properly. In this PR:

- Add test case against successive quotes
- Added fix for successive quotes

I should note that since we have what seem like 2 common regressions (this and #6), we should probably break the escaping portion out into its own module for reuse elsewhere.