### PR TITLE
Implemented quoting of object keys (fixes #1).

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ and add to your esformatter config file:
   ],
   "quotes": {
     "type": "single",
-    "avoidEscape": false
+    "avoidEscape": false,
+    "normalizeObjectKeys": false
   }
 }
 ```
@@ -33,6 +34,8 @@ and add to your esformatter config file:
     - if code should use "single" or "double" quotes.
   - **avoidEscape:Boolean**
     - `true` if you want to avoid escaping quotes when possible.
+  - **normalizeObjectKeys:Boolean**
+    - `true` if you want to enforce quotes on object keys, too.
 
 ```js
 // register plugin
@@ -41,7 +44,8 @@ esformatter.register(require('esformatter-quotes'));
 var output = esformatter.format(str, {
   "quotes": {
     "type": "single",
-    "avoidEscape": false
+    "avoidEscape": false,
+    "normalizeObjectKeys": false
   }
 });
 ```
@@ -106,8 +110,62 @@ var lorem = "ipsum \"dolor\" sit 'amet'";
 var maecennas = "ipsum 'dolor' sit \"amet\"";
 ```
 
+## Examples for object key normalization
+
+Given this input program:
+
+```js
+var famousQuoteBy = {
+  'Princess Leia': 'I love you!',
+  'Han "Shot first" Solo': 'I know!',
+  Spock: 'Fascinating.',
+  "Dr. Emmett 'Doc' Brown": '1.21 gigawatts???'
+};
+
+```
+
+### {type: 'single', normalizeObjectKeys: true}
+```js
+var famousQuoteBy = {
+  'Princess Leia': 'I love you!',
+  'Han "Shot first" Solo': 'I know!',
+  'Spock': 'Fascinating.',
+  'Dr. Emmett \'Doc\' Brown': '1.21 gigawatts???'
+};
+
+```
+
+### {type: 'single', avoidEscape: true, normalizeObjectKeys: true}
+```js
+var famousQuoteBy = {
+  'Princess Leia': 'I love you!',
+  'Han "Shot first" Solo': 'I know!',
+  'Spock': 'Fascinating.',
+  "Dr. Emmett 'Doc' Brown": '1.21 gigawatts???'
+};
+
+```
+
+### {type: 'double', normalizeObjectKeys: true}
+```js
+var famousQuoteBy = {
+  "Princess Leia": "I love you!",
+  "Han \"Shot first\" Solo": "I know!",
+  "Spock": "Fascinating.",
+  "Dr. Emmett 'Doc' Brown": "1.21 gigawatts???"
+};
+```
+
+### {type: 'double', avoidEscape: true, normalizeObjectKeys: true}
+```js
+var famousQuoteBy = {
+  "Princess Leia": "I love you!",
+  'Han "Shot first" Solo': "I know!",
+  "Spock": "Fascinating.",
+  "Dr. Emmett 'Doc' Brown": "1.21 gigawatts???"
+};
+```
 
 ## License
 
 Released under the [MIT License](http://opensource.org/licenses/MIT).
-

--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ var avoidEscape;
 var disabled;
 var quoteValue;
 var alternateQuote;
+var normalizeObjectKeys;
 
 
 exports.setOptions = function(opts) {
@@ -21,6 +22,7 @@ exports.setOptions = function(opts) {
     alternateQuote = opts.type !== 'single' ? SINGLE_QUOTE : DOUBLE_QUOTE;
   }
   avoidEscape = opts.avoidEscape;
+  normalizeObjectKeys = opts.normalizeObjectKeys;
 };
 
 
@@ -28,27 +30,58 @@ exports.tokenBefore = function(token) {
   if (disabled) return;
 
   if (token.type === 'String') {
-    var content = token.value.substr(1, token.value.length - 2);
-    var quote = quoteValue;
-    var alternate = alternateQuote;
-
-    var shouldAvoidEscape = avoidEscape &&
-      content.indexOf(quote) >= 0 &&
-      content.indexOf(alternate) < 0;
-
-    if (shouldAvoidEscape) {
-      alternate = quoteValue;
-      quote = alternateQuote;
-    }
-
-    // we always normalize the behavior to remove unnecessary escapes
-    var alternateEscape = new RegExp('\\\\' + alternate, 'g');
-    content = content.replace(alternateEscape, alternate);
-
-    var quoteEscape = new RegExp('([^\\\\])' + quote, 'g');
-    content = content.replace(quoteEscape, '$1\\' + quote);
-
-    token.value = quote + content + quote;
+    var newTokenValue = getNormalizedStringWithQuotes(token.value);
+    token.value = newTokenValue;
   }
 };
 
+exports.nodeBefore = function(node) {
+  if (disabled || !normalizeObjectKeys) return;
+
+  if (node.type === 'ObjectExpression') {
+    node.properties.forEach(function(property) {
+      if (property.key.type === 'Identifier') {
+        // Literal = The key isn't quoted yet, convert to a Literal.
+        property.key.value = property.key.name;
+        delete property.key.name;
+        property.key.type = 'Literal';
+      }
+
+      property.key.startToken.value = getNormalizedStringWithQuotes(property.key.startToken.value);
+      property.key.endToken.value   = getNormalizedStringWithQuotes(property.key.endToken.value);
+
+      property.key.startToken.type = property.key.endToken.type = 'String';
+    });
+  }
+}
+
+function getNormalizedStringWithQuotes(string) {
+  var content;
+  if (string.charAt(0) === DOUBLE_QUOTE || string.charAt(0) === SINGLE_QUOTE) {
+    content = string.substr(1, string.length - 2);
+  }
+  else {
+    content = string;
+  }
+
+  var quote = quoteValue;
+  var alternate = alternateQuote;
+
+  var shouldAvoidEscape = avoidEscape &&
+    content.indexOf(quote) >= 0 &&
+    content.indexOf(alternate) < 0;
+
+  if (shouldAvoidEscape) {
+    alternate = quoteValue;
+    quote = alternateQuote;
+  }
+
+  // we always normalize the behavior to remove unnecessary escapes
+  var alternateEscape = new RegExp('\\\\' + alternate, 'g');
+  content = content.replace(alternateEscape, alternate);
+
+  var quoteEscape = new RegExp('([^\\\\])' + quote, 'g');
+  content = content.replace(quoteEscape, '$1\\' + quote);
+
+  return quote + content + quote;
+}

--- a/test/compare.spec.js
+++ b/test/compare.spec.js
@@ -8,7 +8,7 @@ var quotes = require('../');
 var expect = require('chai').expect;
 
 
-describe('compare input/output', function() {
+describe('compare input/output for regular strings', function() {
 
   var input;
 
@@ -58,7 +58,59 @@ describe('compare input/output', function() {
       expect(output).to.be.eql(getFile('output-double-avoid.js'));
     });
   });
+});
 
+describe('compare input/output for object keys', function() {
+  var input;
+
+  before(function() {
+    input = getFile('input-keys.js');
+    esformatter.register(quotes);
+  });
+
+  describe('keys', function() {
+    it('should convert non-quoted object keys to single quoted keys', function() {
+        var output = esformatter.format(input, {
+        quotes: {
+          type: 'single',
+          normalizeObjectKeys: true
+        }
+      });
+      expect(output).to.be.eql(getFile('output-keys-single.js'));
+    });
+
+    it('should convert non-quoted object keys to single quoted keys but should avoid escape', function() {
+        var output = esformatter.format(input, {
+        quotes: {
+          type: 'single',
+          avoidEscape: true,
+          normalizeObjectKeys: true
+        }
+      });
+      expect(output).to.be.eql(getFile('output-keys-single-avoid.js'));
+    });
+
+    it('should convert non-quoted object keys to double quoted keys', function() {
+        var output = esformatter.format(input, {
+        quotes: {
+          type: 'double',
+          normalizeObjectKeys: true
+        }
+      });
+      expect(output).to.be.eql(getFile('output-keys-double.js'));
+    });
+
+    it('should convert non-quoted object keys to double quoted keys but should avoid escape', function() {
+        var output = esformatter.format(input, {
+        quotes: {
+          type: 'double',
+          avoidEscape: true,
+          normalizeObjectKeys: true
+        }
+      });
+      expect(output).to.be.eql(getFile('output-keys-double-avoid.js'));
+    });
+  });
 });
 
 

--- a/test/compare/input-keys.js
+++ b/test/compare/input-keys.js
@@ -1,0 +1,9 @@
+var famousQuoteBy = {
+  'Princess Leia': 'I love you!',
+  'Han "Shot first" Solo': 'I know!',
+  Spock: 'Fascinating.',
+  "Dr. Emmett 'Doc' Brown": '1.21 gigawatts???',
+  aChildObject: {
+    withKeys: true
+  }
+};

--- a/test/compare/input.js
+++ b/test/compare/input.js
@@ -39,3 +39,11 @@ ipsum "dolor"';
 var multiAvoidDouble = "dolor sit \
 ipsum 'dolor'";
 
+// keys
+var object = {
+  someKey: 'someValue with "quotes"',
+  someOtherKey: 42,
+  aChildObject: {
+    withKeys: true
+  }
+};

--- a/test/compare/output-double-avoid.js
+++ b/test/compare/output-double-avoid.js
@@ -39,3 +39,11 @@ ipsum "dolor"';
 var multiAvoidDouble = "dolor sit \
 ipsum 'dolor'";
 
+// keys
+var object = {
+  someKey: 'someValue with "quotes"',
+  someOtherKey: 42,
+  aChildObject: {
+    withKeys: true
+  }
+};

--- a/test/compare/output-double.js
+++ b/test/compare/output-double.js
@@ -39,3 +39,11 @@ ipsum \"dolor\"";
 var multiAvoidDouble = "dolor sit \
 ipsum 'dolor'";
 
+// keys
+var object = {
+  someKey: "someValue with \"quotes\"",
+  someOtherKey: 42,
+  aChildObject: {
+    withKeys: true
+  }
+};

--- a/test/compare/output-keys-double-avoid.js
+++ b/test/compare/output-keys-double-avoid.js
@@ -1,0 +1,9 @@
+var famousQuoteBy = {
+  "Princess Leia": "I love you!",
+  'Han "Shot first" Solo': "I know!",
+  "Spock": "Fascinating.",
+  "Dr. Emmett 'Doc' Brown": "1.21 gigawatts???",
+  "aChildObject": {
+    "withKeys": true
+  }
+};

--- a/test/compare/output-keys-double.js
+++ b/test/compare/output-keys-double.js
@@ -1,0 +1,9 @@
+var famousQuoteBy = {
+  "Princess Leia": "I love you!",
+  "Han \"Shot first\" Solo": "I know!",
+  "Spock": "Fascinating.",
+  "Dr. Emmett 'Doc' Brown": "1.21 gigawatts???",
+  "aChildObject": {
+    "withKeys": true
+  }
+};

--- a/test/compare/output-keys-single-avoid.js
+++ b/test/compare/output-keys-single-avoid.js
@@ -1,0 +1,9 @@
+var famousQuoteBy = {
+  'Princess Leia': 'I love you!',
+  'Han "Shot first" Solo': 'I know!',
+  'Spock': 'Fascinating.',
+  "Dr. Emmett 'Doc' Brown": '1.21 gigawatts???',
+  'aChildObject': {
+    'withKeys': true
+  }
+};

--- a/test/compare/output-keys-single.js
+++ b/test/compare/output-keys-single.js
@@ -1,0 +1,9 @@
+var famousQuoteBy = {
+  'Princess Leia': 'I love you!',
+  'Han "Shot first" Solo': 'I know!',
+  'Spock': 'Fascinating.',
+  'Dr. Emmett \'Doc\' Brown': '1.21 gigawatts???',
+  'aChildObject': {
+    'withKeys': true
+  }
+};

--- a/test/compare/output-single-avoid.js
+++ b/test/compare/output-single-avoid.js
@@ -39,3 +39,11 @@ ipsum "dolor"';
 var multiAvoidDouble = "dolor sit \
 ipsum 'dolor'";
 
+// keys
+var object = {
+  someKey: 'someValue with "quotes"',
+  someOtherKey: 42,
+  aChildObject: {
+    withKeys: true
+  }
+};

--- a/test/compare/output-single.js
+++ b/test/compare/output-single.js
@@ -39,3 +39,11 @@ ipsum "dolor"';
 var multiAvoidDouble = 'dolor sit \
 ipsum \'dolor\'';
 
+// keys
+var object = {
+  someKey: 'someValue with "quotes"',
+  someOtherKey: 42,
+  aChildObject: {
+    withKeys: true
+  }
+};


### PR DESCRIPTION
Like suggested in issue #1, I added another config option `normalizeObjectKeys` which can be set to `true` (defaults to `false`) and which converts every object key into a string and applies the usual quote transformation logic of esformatter-quotes, too.

The diff looks probably bigger than it is, because of the test files and because of the refactoring of the actual transform logic, which is still the same, but was put into a `function` to make sure it works the same in the usual String case and in the ObjectKey case, too.
